### PR TITLE
CDPT-600 Add 500 error page

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -2,4 +2,8 @@ class ErrorsController < ApplicationController
   def not_found
     render status: :not_found
   end
+
+  def internal_error
+    render status: :internal_server_error
+  end
 end

--- a/app/views/errors/internal_error.html.erb
+++ b/app/views/errors/internal_error.html.erb
@@ -1,0 +1,7 @@
+<div class="govuk-width-container">
+  <main class="govuk-main-wrapper" id="main-content" role="main">
+    <h1 class="govuk-heading-l">Sorry, there is a problem with the service</h1>
+    <p class="govuk-body">Try again later.</p>
+    <p class="govuk-body"><a href="https://www.gov.uk/contact-court-funds-office" class="govuk-link">Contact the Courts Funds Office</a> if you need to speak to someone about unclaimed court money.</p>
+  </main>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
   end
 
   get "/404", to: "errors#not_found"
+  get "/500", to: "errors#internal_error"
 
   root to: "pages#homepage"
 end


### PR DESCRIPTION
500 errors currently show a generic browser error page, this adds a page that matches the rest of the site:
<img width="1056" alt="Screenshot 2023-03-15 at 11 58 37" src="https://user-images.githubusercontent.com/1190196/225331337-e89cc65b-5a4d-40bf-b8f0-35895b31a7c3.png">
