### PR TITLE
Remove Prod basic auth and enable correct routing

### DIFF
--- a/config/kubernetes/production/ingress.yaml
+++ b/config/kubernetes/production/ingress.yaml
@@ -5,9 +5,7 @@ metadata:
   namespace: find-unclaimed-court-money-production
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: find-unclaimed-court-money-ingress-find-unclaimed-court-money-production-green
-    external-dns.alpha.kubernetes.io/aws-weight: "100"
-    nginx.ingress.kubernetes.io/auth-type: basic
-    nginx.ingress.kubernetes.io/auth-secret: app-secrets
+    external-dns.alpha.kubernetes.io/aws-weight: "0"
 spec:
   tls:
   - hosts:

--- a/config/kubernetes/staging/ingress.yaml
+++ b/config/kubernetes/staging/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: find-unclaimed-court-money-staging
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: find-unclaimed-court-money-ingress-find-unclaimed-court-money-staging-green
-    external-dns.alpha.kubernetes.io/aws-weight: "100"
+    external-dns.alpha.kubernetes.io/aws-weight: "0"
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-secret: app-secrets
 spec:


### PR DESCRIPTION
aws-weight is set to 0 to allow a routing record to be created for the live host, but to not allow any traffic yet.