### PR TITLE
Set aws-weight to 100

### DIFF
--- a/config/kubernetes/production/ingress.yaml
+++ b/config/kubernetes/production/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: find-unclaimed-court-money-production
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: find-unclaimed-court-money-ingress-find-unclaimed-court-money-production-green
-    external-dns.alpha.kubernetes.io/aws-weight: "0"
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
 spec:
   tls:
   - hosts:

--- a/config/kubernetes/staging/ingress.yaml
+++ b/config/kubernetes/staging/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: find-unclaimed-court-money-staging
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: find-unclaimed-court-money-ingress-find-unclaimed-court-money-staging-green
-    external-dns.alpha.kubernetes.io/aws-weight: "0"
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-secret: app-secrets
 spec:


### PR DESCRIPTION
Unfortunately it is not possible to have multiple ingresses for the same URL so this needs to be set to 100.
The ingress for the old service will need to be removed and then this change can be applied.