### PR TITLE
CDPT-850 Allow searching by year carried over

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -26,6 +26,6 @@ class SearchesController < ApplicationController
 private
 
   def search_params
-    params.require(:search).permit(:keywords, :date_from, :date_to)
+    params.require(:search).permit(:keywords, :date_from, :date_to, :carried_over)
   end
 end

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -3,5 +3,6 @@ class Case < ApplicationRecord
 
   scope :from_date, ->(date) { where(case_date: date..) }
   scope :to_date, ->(date) { where(case_date: ..date) }
+  scope :carried_over, ->(year) { where(year_carried_over: year) }
   scope :for_term, ->(term) { where("LOWER(case_name) LIKE :term OR LOWER(credit_details) LIKE :term OR LOWER(account_number) LIKE :term", { term: "%#{term.downcase}%" }) }
 end

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -3,7 +3,7 @@ class Search
   include ActiveModel::Validations
   include ActiveRecord::AttributeAssignment
 
-  attr_accessor :keywords
+  attr_accessor :keywords, :carried_over
   attr_reader :date_from, :date_to
 
   validates :keywords, presence: true, length: { minimum: 3 }
@@ -32,6 +32,7 @@ class Search
     scope = Case if scope.nil?
     scope = scope.from_date(date_from)
     scope = scope.to_date(date_to)
+    scope = scope.carried_over(carried_over) if carried_over&.present?
     scope.order(case_date: :desc)
   end
 
@@ -52,6 +53,10 @@ private
 
     if date_from.is_a?(Date) && date_to.is_a?(Date)
       errors.delete(:keywords)
+    end
+
+    if carried_over.present? && (carried_over.to_i < 1000 || carried_over.to_i > Date.current.year)
+      errors.add(:carried_over, :invalid)
     end
   end
 

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -51,12 +51,12 @@ private
       errors.add(:date_to, :invalid)
     end
 
-    if date_from.is_a?(Date) && date_to.is_a?(Date)
-      errors.delete(:keywords)
-    end
-
     if carried_over.present? && (carried_over.to_i < 1000 || carried_over.to_i > Date.current.year)
       errors.add(:carried_over, :invalid)
+    end
+
+    if (date_from.is_a?(Date) && date_to.is_a?(Date)) || carried_over.present?
+      errors.delete(:keywords)
     end
   end
 

--- a/app/views/searches/new.html.erb
+++ b/app/views/searches/new.html.erb
@@ -19,7 +19,7 @@
         <%= f.govuk_date_field :date_to, legend: { size: "s" } %>
       <% end %>
 
-      <%= f.govuk_text_field :carried_over, label: { size: "s" }, width: 4 %>
+      <%= f.govuk_text_field :carried_over, label: { size: "m" }, width: 4 %>
 
       <%= f.govuk_submit "Search" %>
     <% end %>

--- a/app/views/searches/new.html.erb
+++ b/app/views/searches/new.html.erb
@@ -13,11 +13,15 @@
 
       <p class="govuk-body">You can search using keyword and/or date. Entering specific information will improve the accuracy of your search results.</p>
       <%= f.govuk_text_field :keywords, label: { size: "m" } %>
+
       <%= f.govuk_fieldset legend: { text: 'Search a date range' } do %>
         <%= f.govuk_date_field :date_from, legend: { size: "s" } %>
         <%= f.govuk_date_field :date_to, legend: { size: "s" } %>
-        <%= f.govuk_submit "Search" %>
       <% end %>
+
+      <%= f.govuk_text_field :carried_over, label: { size: "s" }, width: 4 %>
+
+      <%= f.govuk_submit "Search" %>
     <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,7 +47,7 @@ en:
     label:
       search:
         keywords: Search by keywords
-        carried_over: Year carried over
+        carried_over: Search by year carried over
       login:
         name: Login name
       upload:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,8 @@ en:
               invalid: Date from must be a valid date or omitted
             date_to:
               invalid: Date to must be a valid date or omitted
+            carried_over:
+              invalid: Year carried over must be a valid year or omitted
         upload:
           attributes:
             file:
@@ -45,6 +47,7 @@ en:
     label:
       search:
         keywords: Search by keywords
+        carried_over: Year carried over
       login:
         name: Login name
       upload:
@@ -58,3 +61,4 @@ en:
         keywords: For example, name, location, case type, organisation and/or court account number (has 9 characters, for example 27891231P)
         date_from: For example, 27 3 2018
         date_to: For example, 27 3 2021
+        carried_over: For example, 2022

--- a/spec/factories/searches.rb
+++ b/spec/factories/searches.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     keywords { "test" }
     date_from { { 3 => 1, 2 => 1, 1 => 1990 } }
     date_to { { 3 => 31, 2 => 12, 1 => 2020 } }
+    carried_over { "2022" }
   end
 end

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -39,6 +39,20 @@ RSpec.describe Case do
     end
   end
 
+  describe ".carried_over" do
+    let(:case_carried_over_1985) { create(:case, year_carried_over: "1985") }
+    let(:case_carried_over_1986) { create(:case, year_carried_over: "1986") }
+
+    before do
+      case_carried_over_1985
+      case_carried_over_1986
+    end
+
+    it "finds cases with the keyword in case_name" do
+      expect(described_class.carried_over("1985")).to match_array [case_carried_over_1985]
+    end
+  end
+
   describe ".for_term" do
     let!(:case_chicken) { create(:case, case_name: "contains the keyword ChickeN that we are looking for") }
     let!(:case_turkey) { create(:case, credit_details: "contains the keyword TurkeY that we are looking for") }

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -39,6 +39,18 @@ RSpec.describe Search do
     it { is_expected.to be_valid }
   end
 
+  context "with only carried_over year" do
+    subject(:search) { described_class.new(carried_over: "2022") }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  context "with invalid carried_over year" do
+    subject(:search) { described_class.new(keywords: "test", carried_over: "abc") }
+
+    it { is_expected.not_to be_valid }
+  end
+
   describe "#results" do
     it "orders by most recent case date" do
       case_2000 = create(:case, case_name: "test", case_date: Date.new(2000))
@@ -57,6 +69,7 @@ RSpec.describe Search do
         allow(Case).to receive(:for_term).and_return(kase)
         allow(kase).to receive(:to_date).and_return(kase)
         allow(kase).to receive(:from_date).and_return(kase)
+        allow(kase).to receive(:carried_over).and_return(kase)
         allow(kase).to receive(:order).and_return(kase)
       end
 
@@ -79,6 +92,11 @@ RSpec.describe Search do
         search.keywords = "test1,test2"
         allow(Case).to receive(:for_term).with("test1").and_return(kase)
         allow(kase).to receive(:or).with(Case.for_term("test2")).and_return(kase)
+        search.results
+      end
+
+      it "filters by carried_over year" do
+        expect(kase).to receive(:carried_over).with(search.carried_over)
         search.results
       end
     end

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -42,11 +42,11 @@ RSpec.describe Search do
   context "with only carried_over year" do
     subject(:search) { described_class.new(carried_over: "2022") }
 
-    it { is_expected.not_to be_valid }
+    it { is_expected.to be_valid }
   end
 
   context "with invalid carried_over year" do
-    subject(:search) { described_class.new(keywords: "test", carried_over: "abc") }
+    subject(:search) { described_class.new(carried_over: "abc") }
 
     it { is_expected.not_to be_valid }
   end


### PR DESCRIPTION
Adds the ability for users to filter the accounts returned by "year carried over"

<img width="721" alt="Screenshot 2023-08-22 at 13 20 43" src="https://github.com/ministryofjustice/find-unclaimed-court-money/assets/1190196/6a79de6d-4acf-4a56-aab3-a36600df0252">

