### PR TITLE
Recreate build tag for each job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+env:
+  PREFIX: "fum"
+
 concurrency:
   group: deploy-${{ github.ref }}
   cancel-in-progress: true
@@ -15,9 +18,6 @@ jobs:
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read  # This is required for actions/checkout
-
-    outputs:
-      build-tag: ${{ steps.build-tag.outputs.tag }}
 
     steps:
       - name: Checkout
@@ -37,20 +37,18 @@ jobs:
         run: echo "BUILD_DATE=$(date +%Y-%m-%dT%H:%M:%S%z)" >> $GITHUB_ENV
 
       - name: Store build tag
-        id: build-tag
+        id: vars
         run: |
-          prefix="fum"
           branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-          short_version=$(git rev-parse --short ${{ github.sha }})
-          build_tag=$prefix-$branch-$short_version
-          echo "BUILD_TAG=$build_tag" >> $GITHUB_ENV
-          echo "tag=$build_tag" >> $GITHUB_OUTPUT
+          short_sha=$(git rev-parse --short ${{ github.sha }})
+          build_tag=$PREFIX-$branch-$short_sha
+          echo "build_tag=$build_tag" >> $GITHUB_OUTPUT
 
       - name: Build
         run: |
           docker build \
             --build-arg APP_BUILD_DATE=${{ env.BUILD_DATE }} \
-            --build-arg APP_BUILD_TAG=${{ env.BUILD_TAG }} \
+            --build-arg APP_BUILD_TAG=${{ steps.vars.outputs.build_tag }} \
             --build-arg APP_GIT_COMMIT=${{ github.sha }} \
             -t ${{ vars.ECR_URL }}:${{ github.sha }} .
 
@@ -73,6 +71,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Store build tag
+        id: vars
+        run: |
+          branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+          short_sha=$(git rev-parse --short ${{ github.sha }})
+          build_tag=$PREFIX-$branch-$short_sha
+          echo "build_tag=$build_tag" >> $GITHUB_OUTPUT
 
       - name: Update image tag
         env:
@@ -106,7 +112,7 @@ jobs:
               "attachments": [
                 {
                   "color": "#1d990c",
-                  "text": "${{ github.actor }} deployed *${{ needs.build.outputs.build-tag }}* to *Staging*",
+                  "text": "${{ github.actor }} deployed *${{ steps.vars.outputs.build_tag }}* to *Staging*",
                   "fields": [
                     {
                       "title": "Project",
@@ -141,6 +147,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Store build tag
+        id: vars
+        run: |
+          branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+          short_sha=$(git rev-parse --short ${{ github.sha }})
+          build_tag=$PREFIX-$branch-$short_sha
+          echo "build_tag=$build_tag" >> $GITHUB_OUTPUT
+
       - name: Update image tag
         env:
           ECR_URL: ${{ vars.ECR_URL }}
@@ -173,7 +187,7 @@ jobs:
               "attachments": [
                 {
                   "color": "#1d990c",
-                  "text": "${{ github.actor }} deployed *${{ needs.build.outputs.build-tag }}* to *Production*",
+                  "text": "${{ github.actor }} deployed *${{ steps.vars.outputs.build_tag }}* to *Production*",
                   "fields": [
                     {
                       "title": "Project",
@@ -203,7 +217,7 @@ jobs:
               "attachments": [
                 {
                   "color": "#1d990c",
-                  "text": "${{ github.actor }} deployed *${{ needs.build.outputs.build-tag }}* to *Production*",
+                  "text": "${{ github.actor }} deployed *${{ steps.vars.outputs.build_tag }}* to *Production*",
                   "fields": [
                     {
                       "title": "Project",


### PR DESCRIPTION
Trying store the build tag and pass between jobs did not work reliably.
Instead this recreates the build tag for each job so we can output it in the Slack notification.