### PR TITLE
CDPT-1212 Update Account Details page

### DIFF
--- a/app/views/cases/_summary.html.erb
+++ b/app/views/cases/_summary.html.erb
@@ -5,13 +5,13 @@
   end;
 
   summary_list.with_row do |row|
-    row.with_key { "Year carried over" }
-    row.with_value { kase.year_carried_over }
+    row.with_key { "Case name" }
+    row.with_value { kase.case_name }
   end;
 
   summary_list.with_row do |row|
-    row.with_key { "Case name" }
-    row.with_value { kase.case_name }
+    row.with_key { "Credit details" }
+    row.with_value { kase.credit_details }
   end;
 
   summary_list.with_row do |row|
@@ -20,7 +20,17 @@
   end;
 
   summary_list.with_row do |row|
-    row.with_key { "Credit details" }
-    row.with_value { kase.credit_details }
+    row.with_key { "Year carried over" }
+    row.with_value { kase.year_carried_over }
+  end;
+
+  summary_list.with_row do |row|
+    row.with_key { "Initial date of dormancy" }
+    row.with_value { kase.initial_dormancy }
+  end;
+
+  summary_list.with_row do |row|
+    row.with_key { "Last date to submit a claim" }
+    row.with_value { kase.last_claim_date }
   end;
 end; %>

--- a/spec/views/cases/show.html.erb_spec.rb
+++ b/spec/views/cases/show.html.erb_spec.rb
@@ -10,19 +10,27 @@ RSpec.describe "cases/show.html.erb" do
     expect(rendered).to have_text(kase.account_number)
   end
 
-  it "displays the case year carried over" do
-    expect(rendered).to have_text(kase.year_carried_over)
-  end
-
   it "displays the case name" do
     expect(rendered).to have_text(kase.case_name)
+  end
+
+  it "displays the case credit details" do
+    expect(rendered).to have_text(kase.credit_details)
   end
 
   it "displays the case date account opened" do
     expect(rendered).to have_text(kase.date_account_opened)
   end
 
-  it "displays the case credit details" do
-    expect(rendered).to have_text(kase.credit_details)
+  it "displays the case year carried over" do
+    expect(rendered).to have_text(kase.year_carried_over)
+  end
+
+  it "displays the case initial date of dormancy" do
+    expect(rendered).to have_text(kase.initial_dormancy)
+  end
+
+  it "displays the case last date to submit a claim" do
+    expect(rendered).to have_text(kase.last_claim_date)
   end
 end


### PR DESCRIPTION
### Description
Output the new 'Initial date of dormancy' and 'Last date to submit a claim' data on the account summary page.

Also reorder the currently showing fields ad display in this order:

	Account Number
	Case Name
	Credit Details
	Date Account Opened
	Year Carried Over
	Initial date of dormancy
	Last date to submit a claim 

### Jira ticket
https://dsdmoj.atlassian.net/jira/software/c/projects/CDPT/boards/864?assignee=557058%3A2d2f4a33-f427-483f-9c36-338caee60eae&selectedIssue=CDPT-1212

### QA
Search for an account.  The summary page should look like this - 

![fum-account-summary-page](https://github.com/ministryofjustice/find-unclaimed-court-money/assets/6988369/e7a95401-247c-4288-936f-ebba41748ed2)

