### PR TITLE
CDPT-1371 Start page and 'What happens next' content updates

### DIFF
--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -11,31 +11,8 @@
 <%= render "summary", kase: @case %>
 
 <%= govuk_details(summary_text: "What happens next") do %>
-  <h3 class="govuk-heading-s">Provide any further information you know</h3>
-  <p class="govuk-body">So we can identify the account, print these results and send to the Courts Fund Office including any other details you might know, such as the:</p>
-  <ul class="govuk-list govuk-list--bullet">
-    <li>court account name</li>
-    <li>name of the relevant court case</li>
-    <li>court that dealt with the case</li>
-    <li>date of the case</li>
-    <li>name of the person paying the money to the court</li>
-    <li>name of the person the money was awarded to</li>
-  </ul>
-
-  <h3 class="govuk-heading-s">Show evidence you're entitled to claim</h3>
-  <p class="govuk-body">We need evidence that the money could belong to you, someone you're responsible for or are representing. This could be copies of:</p>
-  <ul class="govuk-list govuk-list--bullet">
-    <li><%= govuk_link_to "will or grant of administration", "https://www.gov.uk/wills-probate-inheritance/searching-for-probate-records" %></li>
-    <li><%= govuk_link_to "birth, death or marriage certificates", "https://www.gov.uk/order-copy-birth-death-marriage-certificate" %></li>
-    <li><%= govuk_link_to "census record", "https://www.nationalarchives.gov.uk/help-with-your-research/research-guides/census-records/" %></li>
-    <li>a court order (the court that issued it can provide a copy)</li>
-  </ul>
-
-  <h4 class="govuk-body govuk-!-font-weight-bold">Include your ID</h4>
-  <p class="govuk-body">We also need evidence of your identity, so include a copy of some identification such as a passport or driving licence.</p>
-
-  <h3 class="govuk-heading-s">Send your claim by post</h3>
-  <p class="govuk-body">Court Funds Office<br>Sunderland<br>SR43 3AB</p>
-  <p class="govuk-body">You will receive a reply by letter.</p>
-  <p class="govuk-body">You can find out <%= govuk_link_to "how your personal information will be stored and used", "https://www.gov.uk/government/publications/court-funds-office-privacy-notice" %>.</p>
+  <p class="govuk-body">If you think you could be entitled to money from this account, you will need to get more information from the Court Funds Office before you can make a claim to the court that the money was originally paid to.</p>
+  <p class="govuk-body">Find out what evidence you need to send to the Court Funds Office at <%= govuk_link_to "Find and claim money in an unclaimed court account", "https://www.gov.uk/find-unclaimed-court-money" %>.</p>
+  <p class="govuk-body">If you’re claiming up to 12 months before the last claim date, you must also tell the Court Funds Office as soon as you make your claim to the court.</p>
+  <p class="govuk-body">If the last claim date has passed, you won’t be able to make a claim.</p>
 <% end %>

--- a/app/views/pages/homepage.html.erb
+++ b/app/views/pages/homepage.html.erb
@@ -2,18 +2,37 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Find unclaimed court money</h1>
 
-    <p class="govuk-body">You can find and claim money you're entitled to from a civil court in England and Wales if it has not been claimed.</p>
-    <p class="govuk-body">This could be money paid to or awarded by a court (for example to settle a court case) to you or to someone whose <%= govuk_link_to "estate you're entitled to claim", "https://www.gov.uk/unclaimed-estates-bona-vacantia" %>.</p>
-    <p class="govuk-body">
-      Money paid to a civil court in England and Wales is held in a Court Funds Office account. It's classed as unclaimed if the
-      Court Funds Office has been unable to contact anyone entitled to the money and
-      there has been no activity on the account for over 10 years.
-    </p>
+    <p class="govuk-body">An Unclaimed Court Money account could contain money paid to you or awarded by a court, for example to settle a court case. It could also contain money paid or awarded to someone whose <%= govuk_link_to "estate you're entitled to claim", "https://www.gov.uk/unclaimed-estates-bona-vacantia" %>.</p>
+    <p class="govuk-body">If you find money you think you could be entitled to, find out more about how to <%= govuk_link_to "find and claim money in an unclaimed court account", "https://www.gov.uk/find-unclaimed-court-money" %>.</p>
+    <p class="govuk-body">You must claim money from an account before its last claim date. If you’re claiming up to 12 months before this date, you must also tell the Court Funds Office as soon as you make your claim to the court.</p>
+
+    <div class="govuk-warning-text">
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <strong class="govuk-warning-text__text">
+        <span class="govuk-visually-hidden">Warning</span>
+        From 1 June 2024, you will not be able to claim money from an account that has been unclaimed for 30 years or more.
+      </strong>
+    </div>
+
+    <p class="govuk-body">If you want to claim money from an account with a last claim date before or on 1 June 2024, you need to make your claim to the court by 31 May 2024 and tell the Court Funds Office you have made a claim.</p>
 
     <%= govuk_start_button(text: "Start now", href: "/search") %>
 
     <h2 class="govuk-heading-m">Before you start</h2>
-    <p class="govuk-body">If you can't use the digital service, you can call the Court Funds Office Helpline on <span class="nowrap">0300 0200 199</span>.</p>
+    <p class="govuk-body">If you can't use this service, contact the Court Funds Office by email or phone, or write to the address below.</p>
+    <p class="govuk-body">
+      Court Funds Office<br>
+      <%= govuk_link_to "enquiries@cfo.gov.uk", "mailto:enquiries@cfo.gov.uk" %><br>
+      Telephone:<span class="nowrap">0300 0200 199</span>.<br>
+      Monday to Friday, 9am to 5pm<br>
+      <%= govuk_link_to "Find out about call charges", "https://www.gov.uk/call-charges" %>
+    </br>
+
+    <p class="govuk-body">
+      Court Funds Office<br>
+      Sunderland<br>
+      SR43 3AB
+    </p>
   </div>
 
   <div class="govuk-grid-column-one-third">

--- a/app/views/pages/homepage.html.erb
+++ b/app/views/pages/homepage.html.erb
@@ -2,22 +2,6 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Find unclaimed court money</h1>
 
-    <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-      <div class="govuk-notification-banner__header">
-        <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-          Important
-        </h2>
-      </div>
-      <div class="govuk-notification-banner__content">
-        <p class="govuk-notification-banner__heading">
-          Recent legislation changes have changed how the Court Funds Office (CFO) holds dormant funds. From 01 June 2024, any account that has been unclaimed within the CFO for 30 years or more will be surrendered, and any future right to claim the funds will be extinguished.
-        </p>
-        <p class="govuk-notification-banner__heading">
-          If you are making a claim today, please let CFO know on <a href="mailto:UCM-claiminprogress@cfo.gov.uk">UCM-claiminprogress@cfo.gov.uk</a>
-        </p>
-      </div>
-    </div>
-
     <p class="govuk-body">You can find and claim money you're entitled to from a civil court in England and Wales if it has not been claimed.</p>
     <p class="govuk-body">This could be money paid to or awarded by a court (for example to settle a court case) to you or to someone whose <%= govuk_link_to "estate you're entitled to claim", "https://www.gov.uk/unclaimed-estates-bona-vacantia" %>.</p>
     <p class="govuk-body">

--- a/spec/system/case_spec.rb
+++ b/spec/system/case_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe "Case" do
   end
 
   it "lets me view more information about what to do next for case" do
-    expect(page).not_to have_selector(".govuk-heading-s:first-of-type")
+    expect(page).to have_no_link("Find and claim money in an unclaimed court account", href: "https://www.gov.uk/find-unclaimed-court-money")
     find(".govuk-details__summary-text").click
-    expect(page).to have_selector(".govuk-heading-s:first-of-type")
+    expect(page).to have_link("Find and claim money in an unclaimed court account", href: "https://www.gov.uk/find-unclaimed-court-money")
   end
 end


### PR DESCRIPTION
The home page content has been updated from :

![old-homepage-text](https://github.com/ministryofjustice/find-unclaimed-court-money/assets/6988369/7ac01e64-9036-43ec-a80a-092f8d674108)

To:

![new-homepage-text](https://github.com/ministryofjustice/find-unclaimed-court-money/assets/6988369/20d8817d-bf05-4966-bd40-af3548e7d7d2)

---

The "What happens next" section (at the bottom of the "Account details" pages) text has been updated from

![old-what-happens-next-text](https://github.com/ministryofjustice/find-unclaimed-court-money/assets/6988369/9f9afc62-70d8-408c-ab29-5dca148540c1)

To:

![new-what-happens-next-text](https://github.com/ministryofjustice/find-unclaimed-court-money/assets/6988369/c5e09335-d280-49d4-b827-c8006cda6ff1)

---

**Jira ticket**
https://dsdmoj.atlassian.net/jira/software/c/projects/CDPT/boards/864?assignee=557058%3A2d2f4a33-f427-483f-9c36-338caee60eae&selectedIssue=CDPT-1371
