### PR TITLE
Added missing homepage text.

### DIFF
--- a/app/views/pages/homepage.html.erb
+++ b/app/views/pages/homepage.html.erb
@@ -2,6 +2,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Find unclaimed court money</h1>
 
+    <p class="govuk-body">Use this service to find an 'Unclaimed Court Money' account from a civil court in England and Wales.</p>
     <p class="govuk-body">An Unclaimed Court Money account could contain money paid to you or awarded by a court, for example to settle a court case. It could also contain money paid or awarded to someone whose <%= govuk_link_to "estate you're entitled to claim", "https://www.gov.uk/unclaimed-estates-bona-vacantia" %>.</p>
     <p class="govuk-body">If you find money you think you could be entitled to, find out more about how to <%= govuk_link_to "find and claim money in an unclaimed court account", "https://www.gov.uk/find-unclaimed-court-money" %>.</p>
     <p class="govuk-body">You must claim money from an account before its last claim date. If you’re claiming up to 12 months before this date, you must also tell the Court Funds Office as soon as you make your claim to the court.</p>


### PR DESCRIPTION
Added the missing sentence "Use this service to find an 'Unclaimed Court Money' account from a civil court in England and Wales." to the homepage text.