### PR TITLE
CDPT-1952 Enable modsec detection mode on production

### DIFF
--- a/config/kubernetes/production/ingress.yaml
+++ b/config/kubernetes/production/ingress.yaml
@@ -1,10 +1,10 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: find-unclaimed-court-money-ingress
+  name: find-unclaimed-court-money-ingress-modsec
   namespace: find-unclaimed-court-money-production
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: find-unclaimed-court-money-ingress-find-unclaimed-court-money-production-green
+    external-dns.alpha.kubernetes.io/set-identifier: find-unclaimed-court-money-ingress-modsec-find-unclaimed-court-money-production-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |

--- a/config/kubernetes/production/ingress.yaml
+++ b/config/kubernetes/production/ingress.yaml
@@ -6,7 +6,13 @@ metadata:
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: find-unclaimed-court-money-ingress-find-unclaimed-court-money-production-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecAuditEngine On
+      SecRuleEngine DetectionOnly
+      SecDefaultAction "phase:2,pass,log,tag:github_team=central-digital-product-team,tag:namespace=find-unclaimed-court-money-production"
 spec:
+  ingressClassName: modsec
   tls:
   - hosts:
     - find-unclaimed-court-money.apps.live.cloud-platform.service.justice.gov.uk
@@ -34,4 +40,3 @@ spec:
             name: find-unclaimed-court-money-service
             port:
               number: 3000
-

--- a/config/kubernetes/staging/ingress.yaml
+++ b/config/kubernetes/staging/ingress.yaml
@@ -9,6 +9,7 @@ metadata:
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-secret: app-secrets
 spec:
+  ingressClassName: default
   tls:
   - hosts:
     - staging-find-unclaimed-court-money.apps.live.cloud-platform.service.justice.gov.uk
@@ -36,4 +37,3 @@ spec:
             name: find-unclaimed-court-money-service
             port:
               number: 3000
-


### PR DESCRIPTION
## Description
Enables [modsec](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/networking/modsecurity.html) in detection mode on production so we can be aware of any issues and evaluate if more protection is required.