### PR TITLE
Enable build and deploy from PR

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,12 +1,15 @@
 name: Deploy Workflow
 
 on:
-  workflow_dispatch:
   workflow_call:
 
 env:
   PREFIX: "fum"
   SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+  KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
+  KUBE_CERT: ${{ secrets.KUBE_CERT }}
+  KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
+  KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
 
 concurrency:
   group: deploy-${{ github.ref }}
@@ -15,6 +18,9 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    outputs:
+      build_tag: ${{ steps.vars.outputs.build_tag }}
 
     permissions:
       id-token: write # This is required for requesting the JWT
@@ -65,9 +71,6 @@ jobs:
       id-token: write # This is required for requesting the JWT
       contents: read  # This is required for actions/checkout
 
-    env:
-      KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -81,14 +84,6 @@ jobs:
       - name: Login to container repository
         uses: aws-actions/amazon-ecr-login@v2
         id: login-ec
-
-      - name: Store build tag
-        id: vars
-        run: |
-          branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-          short_sha=$(git rev-parse --short $SHA)
-          build_tag=$PREFIX-$branch-$short_sha
-          echo "build_tag=$build_tag" >> $GITHUB_OUTPUT
 
       - name: Update image tag
         env:
@@ -105,10 +100,6 @@ jobs:
           docker push ${{ vars.ECR_URL }}:staging.latest
 
       - name: Authenticate to the cluster
-        env:
-          KUBE_CERT: ${{ secrets.KUBE_CERT }}
-          KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
-          KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
         run: |
           echo "${KUBE_CERT}" > ca.crt
           kubectl config set-cluster ${KUBE_CLUSTER} --certificate-authority=./ca.crt --server=https://${KUBE_CLUSTER}
@@ -120,35 +111,14 @@ jobs:
         run: |
           kubectl -n ${KUBE_NAMESPACE} apply -f config/kubernetes/staging
 
-      - name: Send deploy notification to product Slack channel
-        uses: slackapi/slack-github-action@v1.27.0
-        with:
-          payload: |
-            {
-              "attachments": [
-                {
-                  "color": "#1d990c",
-                  "text": "${{ github.actor }} deployed *${{ steps.vars.outputs.build_tag }}* to *Staging*",
-                  "fields": [
-                    {
-                      "title": "Project",
-                      "value": "Find Unclaimed Court Money",
-                      "short": true
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "text": "Visit Job",
-                      "type": "button",
-                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                    }
-                  ]
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+  notify-staging:
+    needs: [build, deploy-staging]
+    uses: ./.github/workflows/notification.yml
+    secrets:
+      webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+    with:
+      build_tag: ${{ needs.build.outputs.build_tag }}
+      environment: Staging
 
   deploy-production:
     runs-on: ubuntu-latest
@@ -159,9 +129,6 @@ jobs:
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read  # This is required for actions/checkout
-
-    env:
-      KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
 
     steps:
       - name: Checkout
@@ -176,14 +143,6 @@ jobs:
       - name: Login to container repository
         uses: aws-actions/amazon-ecr-login@v2
         id: login-ecr
-
-      - name: Store build tag
-        id: vars
-        run: |
-          branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-          short_sha=$(git rev-parse --short $SHA)
-          build_tag=$PREFIX-$branch-$short_sha
-          echo "build_tag=$build_tag" >> $GITHUB_OUTPUT
 
       - name: Update image tag
         env:
@@ -200,10 +159,6 @@ jobs:
           docker push ${{ vars.ECR_URL }}:production.latest
 
       - name: Authenticate to the cluster
-        env:
-          KUBE_CERT: ${{ secrets.KUBE_CERT }}
-          KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
-          KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
         run: |
           echo "${KUBE_CERT}" > ca.crt
           kubectl config set-cluster ${KUBE_CLUSTER} --certificate-authority=./ca.crt --server=https://${KUBE_CLUSTER}
@@ -215,62 +170,20 @@ jobs:
         run: |
           kubectl -n ${KUBE_NAMESPACE} apply -f config/kubernetes/production
 
-      - name: Send deploy notification to product Slack channel
-        uses: slackapi/slack-github-action@v1.27.0
-        with:
-          payload: |
-            {
-              "attachments": [
-                {
-                  "color": "#1d990c",
-                  "text": "${{ github.actor }} deployed *${{ steps.vars.outputs.build_tag }}* to *Production*",
-                  "fields": [
-                    {
-                      "title": "Project",
-                      "value": "Find Unclaimed Court Money",
-                      "short": true
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "text": "Visit Job",
-                      "type": "button",
-                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                    }
-                  ]
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+  notify-production:
+    needs: [build, deploy-production]
+    uses: ./.github/workflows/notification.yml
+    secrets:
+      webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+    with:
+      build_tag: ${{ needs.build.outputs.build_tag }}
+      environment: Production
 
-      - name: Send deploy notification to product Slack channel
-        uses: slackapi/slack-github-action@v1.27.0
-        with:
-          payload: |
-            {
-              "attachments": [
-                {
-                  "color": "#1d990c",
-                  "text": "${{ github.actor }} deployed *${{ steps.vars.outputs.build_tag }}* to *Production*",
-                  "fields": [
-                    {
-                      "title": "Project",
-                      "value": "Find Unclaimed Court Money",
-                      "short": true
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "text": "Visit Job",
-                      "type": "button",
-                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                    }
-                  ]
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.PROD_SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+  notify-production-2:
+    needs: [build, deploy-production]
+    uses: ./.github/workflows/notification.yml
+    secrets:
+      webhook_url: ${{ secrets.PROD_SLACK_WEBHOOK_URL }}
+    with:
+      build_tag: ${{ needs.build.outputs.build_tag }}
+      environment: Production

--- a/.github/workflows/notification.yml
+++ b/.github/workflows/notification.yml
@@ -1,0 +1,43 @@
+name: Notification Workflow
+
+on:
+  workflow_call:
+    secrets:
+      webhook_url:
+        required: true
+    inputs:
+      build_tag:
+        required: true
+        type: string
+      environment:
+        required: true
+        type: string
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    name: "notify-${{ inputs.environment }}"
+
+    steps:
+      - name: Slack notification
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          webhook: ${{ secrets.webhook_url }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "attachments": [
+                {
+                  "color": "#1d990c",
+                  "text": "${{ github.actor }} deployed *${{ inputs.build_tag }}* to *${{ inputs.environment }}*",
+                  "fields": [
+                    {
+                      "title": "Project",
+                      "value": "Find Unclaimed Court Money",
+                      "short": true
+                    }
+                  ],
+                  "footer": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                }
+              ]
+            }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test Workflow
+name: CI Workflow
 on:
   pull_request:
   push:
@@ -69,7 +69,6 @@ jobs:
           minimum_file_coverage: 100
 
   build-and-deploy:
-    if: ${{ github.ref == 'refs/heads/main' }}
     needs: test
     uses: ./.github/workflows/deploy.yml
     secrets: inherit


### PR DESCRIPTION
Every commit to a PR will now build the app ready to deploy. This means that a deploy can be made from the PR checks.

Also removes duplicated code to create build tag and send slack notifications.