### PR TITLE
CDPTKAN-1222 Ruby: force_ssl / Secure Cookie where its has been commented out

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,7 +38,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/CDPTKAN-1222

Uncomments `config.force_ssl = true` in config/environments/production.rb                                                                                                                                                                    
                                                                                                                                                                         
The setting was present but commented out, leaving the production app without enforced SSL and without the Secure flag on cookies.