### PR TITLE
CDPTKAN-1221 Switch on Content Security Policy

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,3 +2,10 @@ import { initAll } from "govuk-frontend";
 import "./cookie_banner"
 
 initAll();
+
+document.querySelectorAll("[data-print]").forEach((el) => {
+  el.addEventListener("click", (e) => {
+    e.preventDefault();
+    window.print();
+  });
+});

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -2,11 +2,11 @@
   <%= t('page_title.case') %>
 <% end %>
 
-<%= govuk_back_link(href: "javascript:history.go(-1)") %>
+<%= govuk_back_link(href: request.referer || root_path) %>
 
 <h1 class="govuk-heading-xl">Account details</h1>
 
-<%= govuk_button_link_to "Print account details", "javascript:window.print()" %>
+<%= govuk_button_link_to "Print account details", "#", data: { print: true } %>
 
 <%= render "summary", kase: @case %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
 
     <% if analytics_allowed? %>
       <!-- Google Tag Manager -->
-      <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      <script nonce="<%= content_security_policy_nonce %>">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
       new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
       j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
@@ -29,7 +29,7 @@
   </head>
 
   <body class="govuk-template__body govuk-frontend-supported">
-    <script>
+    <script nonce="<%= content_security_policy_nonce %>">
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>
 

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,22 +4,23 @@
 # See the Securing Rails Applications Guide for more information:
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
 
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap and inline scripts
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src)
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    policy.default_src :self
+    policy.font_src    :self, :data
+    policy.img_src     :self, :data, "https://www.googletagmanager.com"
+    policy.object_src  :none
+    policy.script_src  :self, "https://www.googletagmanager.com"
+    policy.style_src   :self
+    policy.frame_src   "https://www.googletagmanager.com"
+    policy.connect_src :self,
+                       "https://www.google-analytics.com",
+                       "https://analytics.google.com",
+                       "https://www.googletagmanager.com"
+    policy.base_uri    :self
+  end
+
+  # Per-request nonce added to script-src; inline <script> tags must carry the nonce attribute.
+  config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
+  config.content_security_policy_nonce_directives = %w[script-src]
+end


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/CDPTKAN-1222

 - Enables the content_security_policy.rb initializer with a strict, nonce-based policy covering script-src, style-src, img-src, font-src, frame-src, connect-src, object-src, and base-uri
 - Adds per-request SecureRandom.base64(16) nonces to script-src and applies them to both inline <script> blocks in the layout (GTM initialiser and js-enabled class assignment)
 - Replaces two javascript: URI usages in cases/show that would be blocked by the policy: back link now uses request.referer || root_path; print button uses a data-print attribute with a JS event listener in application.js