### PR TITLE
[NO-TICKET] Fix Prometheus exporter conn error

### DIFF
--- a/config/initializers/prometheus_exporter.rb
+++ b/config/initializers/prometheus_exporter.rb
@@ -1,0 +1,11 @@
+# Locally there's no metrics sidecar on port 9394, so Prometheus clients log
+# repeated "Connection refused" errors. Start the exporter in-process for
+# development only to give them a collector and silence those errors.
+#
+# Once running, metrics are available at http://localhost:9394/metrics
+#
+# Source: https://www.rubydoc.info/gems/govuk_app_config/9.24.1
+if Rails.env.development?
+  require "govuk_app_config/govuk_prometheus_exporter"
+  GovukPrometheusExporter.configure
+end


### PR DESCRIPTION
When prometheus exporter runs locally it expects a metrics container to be running that can collect the metrics data. The current workaround was to manually launch the container in a separate terminal. Otherwise this repeated error occurs: `E, [2026-07-28T09:11:05.827095 #76078] ERROR -- : Prometheus Exporter, failed to send message Connection refused - connect(2) for "localhost" port 9394 `